### PR TITLE
feat: Chess Analyzer UX and analysis improvements

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,18 @@
         </div>
 
         <div id="board-container">
-            <div id="board"></div>
+            <div id="board-wrapper">
+                <div id="board"></div>
+                <div id="board-selected-player-label" class="board-player-label"></div>
+            </div>
+        </div>
+    </div>
+
+    <div id="player-choice-panel" class="player-choice-panel" style="display: none;">
+        <p class="player-choice-title">Analyze moves for which player?</p>
+        <div class="player-choice-buttons">
+            <button type="button" id="btnAnalyzeWhite" class="player-choice-btn">White</button>
+            <button type="button" id="btnAnalyzeBlack" class="player-choice-btn">Black</button>
         </div>
     </div>
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "chess-analyzer",
+  "private": true,
+  "scripts": {
+    "start": "npx --yes http-server -p 8080 -a 0.0.0.0 -c-1",
+    "serve": "npx --yes http-server -p 8080 -a 0.0.0.0 -c-1"
+  }
+}

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -20,8 +20,8 @@ export function updateEvalBar(score) {
 
   $("#eval-fill").css("height", percent + "%");
 
-  // Format the text label
-  let label = score > 0 ? "+" + score.toFixed(1) : score.toFixed(1);
+  // Format the text label (4-digit style e.g. 10.01, -5.20)
+  let label = score > 0 ? "+" + score.toFixed(2) : score.toFixed(2);
   $("#eval-score").text(label);
 }
 
@@ -31,4 +31,72 @@ export function toggleSetupMenu() {
 
 export function hideSetupMenu() {
   $("#setup-area").hide();
+}
+
+const SUGGESTED_CLASS = "suggested-move";
+const LAST_MOVE_CLASS = "last-move";
+
+/** Highlight the suggested (engine) best move on the board. uciMove is e.g. "e2e4" or "e7e8q". */
+export function highlightSuggestedMove(uciMove) {
+  if (!uciMove || uciMove.length < 4) return;
+  const from = uciMove.substring(0, 2);
+  const to = uciMove.substring(2, 4);
+  $(`#board .${SUGGESTED_CLASS}`).removeClass(`${SUGGESTED_CLASS} suggested-from suggested-to`);
+  $(`#board .square-${from}`).addClass(`${SUGGESTED_CLASS} suggested-from`);
+  $(`#board .square-${to}`).addClass(`${SUGGESTED_CLASS} suggested-to`);
+}
+
+/** Remove suggested-move highlights from the board. */
+export function clearSuggestedMoveHighlight() {
+  $(`#board .${SUGGESTED_CLASS}`).removeClass(`${SUGGESTED_CLASS} suggested-from suggested-to`);
+}
+
+/** Highlight the current/last played move on the board (from and to squares). */
+export function highlightLastMove(fromSquare, toSquare) {
+  $(`#board .${LAST_MOVE_CLASS}`).removeClass(`${LAST_MOVE_CLASS} last-move-from last-move-to`);
+  if (fromSquare && toSquare) {
+    $(`#board .square-${fromSquare}`).addClass(`${LAST_MOVE_CLASS} last-move-from`);
+    $(`#board .square-${toSquare}`).addClass(`${LAST_MOVE_CLASS} last-move-to`);
+  }
+}
+
+/** Remove last-move highlight from the board. */
+export function clearLastMoveHighlight() {
+  $(`#board .${LAST_MOVE_CLASS}`).removeClass(`${LAST_MOVE_CLASS} last-move-from last-move-to`);
+}
+
+/** Show panel to choose which player's moves to analyze. onSelect('white'|'black') when chosen. */
+export function showPlayerChoice(whiteName, blackName, onSelect) {
+  const w = whiteName && whiteName.trim() ? `White: ${whiteName.trim()}` : "White";
+  const b = blackName && blackName.trim() ? `Black: ${blackName.trim()}` : "Black";
+  $("#btnAnalyzeWhite").text(w).attr("title", w);
+  $("#btnAnalyzeBlack").text(b).attr("title", b);
+  $("#player-choice-panel").show();
+  $("#btnAnalyzeWhite").off("click").on("click", function () {
+    $("#player-choice-panel").hide();
+    onSelect("white");
+  });
+  $("#btnAnalyzeBlack").off("click").on("click", function () {
+    $("#player-choice-panel").hide();
+    onSelect("black");
+  });
+}
+
+/** Hide the player choice panel. */
+export function hidePlayerChoice() {
+  $("#player-choice-panel").hide();
+}
+
+/** Show only the selected player's name at the bottom of the board. */
+export function updateBoardPlayerLabels(whiteName, blackName, analyzeForColor) {
+  const label = $("#board-selected-player-label");
+  if (!analyzeForColor) {
+    label.text("").hide();
+    return;
+  }
+  const name =
+    analyzeForColor === "white"
+      ? (whiteName && whiteName.trim() ? whiteName.trim() : "White")
+      : (blackName && blackName.trim() ? blackName.trim() : "Black");
+  label.text(name).addClass("analyzing").show();
 }

--- a/styles/style.css
+++ b/styles/style.css
@@ -22,7 +22,8 @@ body {
 
 /* Eval Bar */
 #eval-bar-container {
-  width: 25px;
+  width: 38px;
+  min-width: 38px;
   height: 400px; /* Matches board height */
   background: #333;
   border-radius: 4px;
@@ -40,13 +41,21 @@ body {
 }
 #eval-score {
   position: absolute;
-  top: 5px;
+  top: 4px;
+  left: 0;
+  right: 0;
   width: 100%;
   text-align: center;
-  font-size: 11px;
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
   color: #000;
   z-index: 2;
   font-weight: bold;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: clip;
+  box-sizing: border-box;
+  padding: 0 2px;
 }
 
 /* Board Wrapper */
@@ -57,10 +66,116 @@ body {
   min-width: 0; /* Prevents flexbox overflow issues */
 }
 
+#board-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+  max-width: 400px;
+}
+
+.board-player-label {
+  width: 100%;
+  text-align: center;
+  font-size: 13px;
+  font-weight: 600;
+  color: #bbb;
+  padding: 6px 0;
+  min-height: 28px;
+  box-sizing: border-box;
+}
+.board-player-label.analyzing {
+  color: #81b64c;
+  font-weight: bold;
+}
+
 /* Board */
 #board {
   width: 100%;
   max-width: 400px;
+}
+
+/* Player choice (after PGN load) */
+.player-choice-panel {
+  width: 100%;
+  max-width: 440px;
+  margin-top: 12px;
+  padding: 16px;
+  background: #2d2d2d;
+  border-radius: 8px;
+  border: 1px solid #444;
+}
+.player-choice-title {
+  margin: 0 0 12px 0;
+  font-size: 14px;
+  color: #ddd;
+  text-align: center;
+}
+.player-choice-buttons {
+  display: flex;
+  gap: 10px;
+  justify-content: center;
+}
+.player-choice-btn {
+  flex: 1;
+  min-width: 0;
+  max-width: 200px;
+  padding: 12px 10px;
+  font-size: 14px;
+  border-radius: 6px;
+  border: 2px solid transparent;
+  cursor: pointer;
+  transition: border-color 0.2s, background 0.2s;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.player-choice-btn:hover {
+  border-color: #81b64c;
+  opacity: 1;
+}
+#btnAnalyzeWhite {
+  background: #f0d9b5;
+  color: #333;
+}
+#btnAnalyzeBlack {
+  background: #5c4033;
+  color: #f0d9b5;
+}
+
+/* Prevent pieces from overlapping rank/file notation (1,2,3 and a,b,c,d) */
+#board [class*="square-"] [class*="piece-"],
+#board [class*="square-"] img[data-piece] {
+  max-width: 82%;
+  max-height: 82%;
+  object-fit: contain;
+  display: block;
+  margin: auto;
+  z-index: 1;
+}
+#board [class*="notation-"] {
+  z-index: 2;
+  pointer-events: none;
+}
+
+/* Last played move (current move) highlight – always visible */
+#board .last-move-from {
+  box-shadow: inset 0 0 0 2px rgba(255, 193, 7, 0.85);
+  background-color: rgba(255, 193, 7, 0.2) !important;
+}
+#board .last-move-to {
+  box-shadow: inset 0 0 0 2px rgba(255, 193, 7, 0.85);
+  background-color: rgba(255, 193, 7, 0.35) !important;
+}
+
+/* Suggested (engine) best move highlight – shown after player moves */
+#board .suggested-from {
+  box-shadow: inset 0 0 0 3px rgba(33, 150, 243, 0.9);
+  background-color: rgba(33, 150, 243, 0.25) !important;
+}
+#board .suggested-to {
+  box-shadow: inset 0 0 0 3px rgba(76, 175, 80, 0.9);
+  background-color: rgba(76, 175, 80, 0.35) !important;
 }
 
 /* Coach Panel */


### PR DESCRIPTION
- Show suggested (engine) best move on board for selected player only
- Highlight last played move (amber) and best move (blue/green) on board
- After PGN load: choose which player to analyze (White/Black) with board flip
- Display selected player name at bottom of board only
- Best move = move selected player should have played (from position before their move)
- Smooth piece animation (moveSpeed 450ms, appearSpeed 350ms)
- Eval bar: 4-digit display (e.g. 10.01), fixed width to prevent overflow
- Prevent pieces overlapping rank/file notation (1-8, a-h)
- Player selection buttons: ellipsis for long names, tooltip with full name
- Add package.json with npm run start for local network serving (0.0.0.0)